### PR TITLE
JSON.stringify the save state export before b64 encoding it.

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,7 @@
                 alert("No save state to export.");
             } else {
                 try {
-                    var base64Data = btoa(existingTests);
+                    var base64Data = btoa(JSON.stringify(existingTests));
                     prompt("Copy your save state: ", base64Data);
                 } catch (error) {
                     alert("Error encoding data: " + error);


### PR DESCRIPTION
The base 64 exports of save state have been garbage for a while. Hopefully calling JSON.stringify and then b64 encoding will fix the issue.